### PR TITLE
Fix Font Settings not propagating to the Channel View

### DIFF
--- a/WinIRC/Views/ChannelView.xaml.cs
+++ b/WinIRC/Views/ChannelView.xaml.cs
@@ -229,12 +229,12 @@ namespace WinIRC.Views
 
             if (Config.Contains(Config.FontFamily))
             {
-                // this.messagesView.FontFamily = new FontFamily(Config.GetString(Config.FontFamily));
+                this.messagesView.FontFamily = new FontFamily(Config.GetString(Config.FontFamily));
             }
 
             if (Config.Contains(Config.FontSize))
             {
-                // this.messagesView.FontSize = Convert.ToDouble(Config.GetString(Config.FontSize));
+                this.messagesView.FontSize = Convert.ToDouble(Config.GetString(Config.FontSize));
             }
 
             if (currentChannel != "Server")


### PR DESCRIPTION
Hi!

I was using WinIRC and I found out that the font settings didn't affect anything. Here's a fix for that